### PR TITLE
Refactor certificate caching in SystemSigner

### DIFF
--- a/certificate_freebsd.go
+++ b/certificate_freebsd.go
@@ -7,10 +7,6 @@ import (
 	"strings"
 )
 
-var (
-	certificateCache *tls.Certificate
-)
-
 func ListCertificates(certStoreName string) ([]string, error) {
 	var certNames []string
 
@@ -31,8 +27,11 @@ func ListCertificates(certStoreName string) ([]string, error) {
 }
 
 func (s *SystemSigner) GetClientCertificate(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
-	if certificateCache != nil {
-		return certificateCache, nil
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.certificate != nil {
+		return s.certificate, nil
 	}
 
 	certFile := filepath.Join("/usr/local/etc/ssl/certs", s.CommonName+".crt")
@@ -44,7 +43,7 @@ func (s *SystemSigner) GetClientCertificate(info *tls.CertificateRequestInfo) (*
 		return nil, err
 	}
 
-	certificateCache = &cert
+	s.certificate = &cert
 
-	return certificateCache, nil
+	return s.certificate, nil
 }

--- a/certificate_linux.go
+++ b/certificate_linux.go
@@ -7,10 +7,6 @@ import (
 	"strings"
 )
 
-var (
-	certificateCache *tls.Certificate
-)
-
 func ListCertificates(certStoreName string) ([]string, error) {
 	var certNames []string
 
@@ -31,8 +27,11 @@ func ListCertificates(certStoreName string) ([]string, error) {
 }
 
 func (s *SystemSigner) GetClientCertificate(info *tls.CertificateRequestInfo) (*tls.Certificate, error) {
-	if certificateCache != nil {
-		return certificateCache, nil
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if s.certificate != nil {
+		return s.certificate, nil
 	}
 
 	certFile := filepath.Join("/etc/pki/certs", s.CommonName+".crt")
@@ -44,7 +43,7 @@ func (s *SystemSigner) GetClientCertificate(info *tls.CertificateRequestInfo) (*
 		return nil, err
 	}
 
-	certificateCache = &cert
+	s.certificate = &cert
 
-	return certificateCache, nil
+	return s.certificate, nil
 }

--- a/signer.go
+++ b/signer.go
@@ -1,5 +1,10 @@
 package mTLS
 
+import (
+	"crypto/tls"
+	"sync"
+)
+
 const (
 	CertStoreNameFileP12      = "FILE_P12" // TODO implement
 	CertStoreNameFilePEM      = "FILE_PEM" // TODO implement
@@ -11,6 +16,9 @@ const (
 type SystemSigner struct {
 	CertStoreName string
 	CommonName    string
+
+	mu          sync.Mutex
+	certificate *tls.Certificate
 }
 
 type EmbeddedSigner struct {


### PR DESCRIPTION
## Summary
- remove global certificate cache on Linux and FreeBSD
- add mutex-protected certificate cache to SystemSigner
- load and reuse certificate only once per signer

## Testing
- `go vet ./...`
- `go build ./...`
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bb531eb718832ea4f3e82ec468f9e3