### PR TITLE
Prevent CoreFoundation error leaks in Darwin signer

### DIFF
--- a/signer_darwin.go
+++ b/signer_darwin.go
@@ -86,8 +86,11 @@ func (k *CustomSigner) Sign(_ io.Reader, digest []byte, opts crypto.SignerOpts) 
 	)
 	if cfErrorRef != 0 {
 		cdescription := C.CFErrorCopyDescription(cfErrorRef)
-		fmt.Printf("DEBUG: %v", CFStringToString(cdescription))
-		return nil, fmt.Errorf("failed to sign data: %v", CFStringToString(cdescription))
+		defer C.CFRelease(C.CFTypeRef(cdescription))
+		desc := CFStringToString(cdescription)
+		fmt.Printf("DEBUG: %v", desc)
+		C.CFRelease(C.CFTypeRef(cfErrorRef))
+		return nil, fmt.Errorf("failed to sign data: %v", desc)
 	}
 	defer C.CFRelease(C.CFTypeRef(signCFData))
 

--- a/signer_darwin_mem_test.go
+++ b/signer_darwin_mem_test.go
@@ -1,0 +1,40 @@
+//go:build darwin && cgo
+
+package mTLS
+
+/*
+#cgo LDFLAGS: -framework CoreFoundation -framework Security
+#include <CoreFoundation/CoreFoundation.h>
+#include <Security/Security.h>
+*/
+import "C"
+
+import (
+	"crypto"
+	"crypto/x509"
+	"runtime"
+	"testing"
+)
+
+// TestSignErrorDoesNotLeakMemory ensures that repeated signing errors do not
+// grow memory usage, indicating proper release of CoreFoundation objects.
+func TestSignErrorDoesNotLeakMemory(t *testing.T) {
+	signer := &CustomSigner{x509Cert: &x509.Certificate{}, privateKey: 0}
+	digest := make([]byte, 32)
+
+	runtime.GC()
+	var mStart, mEnd runtime.MemStats
+	runtime.ReadMemStats(&mStart)
+
+	for i := 0; i < 1000; i++ {
+		if _, err := signer.Sign(nil, digest, crypto.SHA256); err == nil {
+			t.Fatalf("expected signing error")
+		}
+	}
+
+	runtime.GC()
+	runtime.ReadMemStats(&mEnd)
+	if diff := int64(mEnd.Alloc) - int64(mStart.Alloc); diff > 1<<20 {
+		t.Fatalf("memory allocation increased by %d bytes", diff)
+	}
+}


### PR DESCRIPTION
## Summary
- release `CFErrorRef` and its description when signing fails on Darwin
- add test ensuring repeated signing errors do not grow memory usage

## Testing
- `go test ./...`
- `go vet ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bb5c073968832e9fe807f19677ffb8