### PR TITLE
Validate digest length and handle hash algorithm errors

### DIFF
--- a/signer_darwin.go
+++ b/signer_darwin.go
@@ -74,6 +74,10 @@ func (k *CustomSigner) Sign(_ io.Reader, digest []byte, opts crypto.SignerOpts) 
 	fmt.Println("DEBUG: Requested signature scheme -", opts.HashFunc().String())
 	fmt.Println("DEBUG: Requested signature scheme -", supportedAlgorithm)
 
+	if len(digest) == 0 {
+		return nil, fmt.Errorf("invalid digest length")
+	}
+
 	// Convert the digest to a CFDataRef
 	digestCFData := C.CFDataCreate(C.kCFAllocatorDefault, (*C.UInt8)(unsafe.Pointer(&digest[0])), C.CFIndex(len(digest)))
 	defer C.CFRelease(C.CFTypeRef(digestCFData))


### PR DESCRIPTION
## Summary
- prevent out-of-bounds digest access in macOS and Windows signers
- surface UTF16 conversion errors when constructing hash algorithm identifiers

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_68bb6899fe98832ebc4a5a30a0e1a993